### PR TITLE
Improve help message

### DIFF
--- a/bin/phinder
+++ b/bin/phinder
@@ -24,7 +24,18 @@ $errorCount = 0;
 function showHelpAndDie($msg=null) {
     if ($msg !== null) fwrite(STDERR, $msg . "\n");
     fwrite(STDERR, <<<EOS
-usage  : phinder [-h] [test] [-j|--json] [-r|--rule <rule-path>]  [-p|--php <php-path>] [-q|--quicktest <pattern>]
+Usage: phinder [options] [command]
+
+Command:
+  test                       Verify phinder.yml
+
+Options:
+  -q, --quicktest <pattern>  Run quick test for <pattern>
+  -p, --php <file>|<dir>     Find pieces in <file> or in all PHP files in <div>
+  -r, --rule <file>|<dir>    Use <file> or all YAML files in <dir> instead of phinder.yml
+  -j, --json                 Output JSON format
+  -h, --help                 Show help
+  -v, --version              Print version number
 
 EOS
 );

--- a/bin/phinder
+++ b/bin/phinder
@@ -31,7 +31,7 @@ Command:
 
 Options:
   -q, --quicktest <pattern>  Run quick test for <pattern>
-  -p, --php <file>|<dir>     Find pieces in <file> or in all PHP files in <div>
+  -p, --php <file>|<dir>     Find pieces in <file> or in all PHP files in <dir>
   -r, --rule <file>|<dir>    Use <file> or all YAML files in <dir> instead of phinder.yml
   -j, --json                 Output JSON format
   -h, --help                 Show help


### PR DESCRIPTION
This PR improves a help message printed by `-h` / `--help` option.
Because I want to see `phinder` comannd's more detail usage in my command-line terminal.

I borrow it from ["Command Line Options"](https://github.com/sider/phinder#command-line-options) in README.

If there are any problems, please do not hesitate to point out!

```
$ bin/phinder -h
Usage: phinder [options] [command]

Command:
  test                       Verify phinder.yml

Options:
  -q, --quicktest <pattern>  Run quick test for <pattern>
  -p, --php <file>|<dir>     Find pieces in <file> or in all PHP files in <div>
  -r, --rule <file>|<dir>    Use <file> or all YAML files in <dir> instead of phinder.yml
  -j, --json                 Output JSON format
  -h, --help                 Show help
  -v, --version              Print version number
```