### PR TITLE
Docker supports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM php:7.3-alpine
+
+# Setup environment
+RUN apk update && \
+    apk add --virtual .build-deps --update --no-cache openssl ca-certificates && \
+    update-ca-certificates
+
+# Install Composer
+ENV COMPOSER_ALLOW_SUPERUSER=1 \
+    PATH="${PATH}:/root/.composer/vendor/bin"
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+# Install Phinder
+ENV PHINDER_VERSION 0.6.1
+RUN composer global require "sider/phinder:${PHINDER_VERSION}"
+
+RUN apk del .build-deps
+
+WORKDIR /workdir
+
+ENTRYPOINT ["phinder"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Phinder: PHP Code Piece Finder
+[![CircleCI](https://circleci.com/gh/sider/phinder/tree/master.svg?style=svg)](https://circleci.com/gh/sider/phinder/tree/master)
+[![Latest Stable Version](https://poser.pugx.org/sider/phinder/v/stable)](https://packagist.org/packages/sider/phinder)
+[![Docker Hub](https://img.shields.io/badge/docker-ready-blue.svg)](https://hub.docker.com/r/sider/phinder/)
 
 Phinder is a tool to find code pieces (technically PHP expressions).
 This tool aims mainly at speeding up your code review process, not static bug detection.
@@ -21,20 +24,17 @@ Phinder is a command line tool for checking such low-level things automatically.
 
 ## Installation
 
+Phinder requires PHP >= 7.0. You can install with [Composer](https://getcomposer.org/):
+
 ```bash
-composer global require sider/phinder
+composer require --dev sider/phinder
+vendor/bin/phinder -v
 ```
 
-You can check your installation by the following command:
+You can also use [Docker](https://hub.docker.com/r/sider/phinder/):
 
 ```bash
-~/.composer/vendor/bin/phinder --help
-```
-
-If you have `$HOME/.composer/vendor/bin` in your PATH, you can also check it by the following:
-
-```bash
-phinder --help
+docker run --rm -t -v $(pwd):/workdir sider/phinder
 ```
 
 ## Documentation


### PR DESCRIPTION
To provide official Docker image is a good way to make it easy to try the power of Phinder :v: 
After getting to merge this PR, the release task should include updating the Docker image. The following is example:

```bash
docker build -t sider/phinder:0.6.1 .
docker tag sider/phinder:0.6.1 sider/phinder:latest
docker push sider:phinder:0.6.1
docker push sider:phinder
```