### PR TITLE
Add new `phinder init` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,55 @@ If you have `$HOME/.composer/vendor/bin` in your PATH, you can also check it by 
 phinder --help
 ```
 
+## Quick start
+
+As a first step, you can run `phinder init` command to create an example `phinder.yml`:
+
+```bash
+$ phinder init
+`phinder.yml` has been created successfully
+$ cat phinder.yaml
+# Feel free to add your own project rules to this YAML file.
+# The following example describes the rule syntax.
+# See the documentation for more details: https://github.com/sider/phinder/tree/master/doc
+
+- # The rule identifier. It must be unique in the YAML file.
+  id: sample.var_dump
+  # Pattern syntax. The `...` pattern matches variable length arguments or array pairs.
+  # As a result, this pattern matches `var_dump` function call with any arguments.
+  pattern: var_dump(...)
+  # The message to display when code pieces are matched with the pattern.
+  message: Do not use var_dump.
+  # Exceptions that can ignore this violation.
+  justification: Allowed when debugging
+
+- id: sample.in_array_without_3rd_param
+  # `_` pattern mattches any single expression.
+  # This means the pattern always matches `in_array` function call with any two arguments.
+  pattern: in_array(_, _)
+  message: Specify 3rd parameter explicitly when calling in_array to avoid unexpected comparison results.
+  # You can test whether your pattern works as expected with `phinder test`.
+  test:
+    # Code pieces that will match your pattern.
+    # This means the following codes are bad as you expected.
+    fail:
+      - in_array(1, $arr)
+      - in_array(2, $arr)
+    # Code pieces that will NOT match your pattern.
+    # This means the following codes are good as you expected.
+    pass:
+      - in_array(3, $arr, true)
+      - in_array(4, $arr, false)
+```
+
+Next you can run `phinder` command to *phind* patterns against your code base.
+
+```bash
+$ phinder
+```
+
+After understanding how a pattern matches your code, let's add more useful rules for a real your project. The possibilities are infinite!
+
 ## Documentation
 
 - [Sample rule and its description](./doc/rule.md)

--- a/bin/phinder
+++ b/bin/phinder
@@ -17,6 +17,7 @@ $rulePath = 'phinder.yml';
 $jsonOutput = false;
 $outputBuffer = ['result' => [], 'errors' => []];
 $command = null;
+$init = false;
 $test = false;
 $violationCount = 0;
 $errorCount = 0;
@@ -27,6 +28,7 @@ function showHelpAndDie($msg=null) {
 Usage: phinder [options] [command]
 
 Command:
+  init                       Create example phinder.yml
   test                       Verify phinder.yml
 
 Options:
@@ -47,6 +49,10 @@ array_shift($argv);
 while ($argv) {
     $a = array_shift($argv);
     switch ($a) {
+        case 'init':
+            $init = true;
+            break;
+
         case 'test':
             $test = true;
             break;
@@ -86,6 +92,21 @@ while ($argv) {
         default:
             showHelpAndDie("Unknown argument: $a");
     }
+}
+
+if ($init === true) {
+    if(file_exists($rulePath)) {
+        fwrite(STDERR, "Cannot generate $rulePath: file already exists".PHP_EOL);
+        exit(1);
+    }
+
+    if(!copy(__DIR__ . '/../sample/phinder.yml', $rulePath)) {
+        fwrite(STDERR, "Cannot generate $rulePath: failed to copy".PHP_EOL);
+        exit(1);
+    }
+
+    fwrite(STDOUT, "`$rulePath` has been created successfully".PHP_EOL);
+    exit(0);
 }
 
 if ($test === true) {

--- a/sample/phinder.yml
+++ b/sample/phinder.yml
@@ -1,15 +1,31 @@
-- id: sample.var_dump
+# Feel free to add your own project rules to this YAML file.
+# The following example describes the rule syntax.
+# See the documentation for more details: https://github.com/sider/phinder/tree/master/doc
+
+- # The rule identifier. It must be unique in the YAML file.
+  id: sample.var_dump
+  # Pattern syntax. The `...` pattern matches variable length arguments or array pairs.
+  # As a result, this pattern matches `var_dump` function call with any arguments.
   pattern: var_dump(...)
+  # The message to display when code pieces are matched with the pattern.
   message: Do not use var_dump.
+  # Exceptions that can ignore this violation.
   justification: Allowed when debugging
 
 - id: sample.in_array_without_3rd_param
+  # `_` pattern mattches any single expression.
+  # This means the pattern always matches `in_array` function call with any two arguments.
   pattern: in_array(_, _)
   message: Specify 3rd parameter explicitly when calling in_array to avoid unexpected comparison results.
+  # You can test whether your pattern works as expected with `phinder test`.
   test:
+    # Code pieces that will match your pattern.
+    # This means the following codes are bad as you expected.
     fail:
       - in_array(1, $arr)
       - in_array(2, $arr)
+    # Code pieces that will NOT match your pattern.
+    # This means the following codes are good as you expected.
     pass:
       - in_array(3, $arr, true)
       - in_array(4, $arr, false)

--- a/test/CLITest.php
+++ b/test/CLITest.php
@@ -1,0 +1,51 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Phinder\API;
+
+
+class CLITest extends TestCase
+{
+    function testInit()
+    {
+        $work_dir = getcwd();
+        try {
+            chdir(__DIR__ . "/res");
+
+            $this->assertFileNotExists("phinder.yml");
+            exec(__DIR__ . "/../bin/phinder init");
+            $this->assertFileExists("phinder.yml");
+
+            $expected = file_get_contents(__DIR__ . "/../sample/phinder.yml");
+            $got = file_get_contents("phinder.yml");
+            $this->assertSame($expected, $got);
+        } finally {
+            if (file_exists("phinder.yml")) {
+                unlink("phinder.yml");
+            }
+            chdir($work_dir);
+        }
+    }
+
+    function testInitWhenConfigAlreadyExists()
+    {
+        $work_dir = getcwd();
+        try {
+            chdir(__DIR__ . "/res");
+            touch("phinder.yml");
+
+            $this->assertFileExists("phinder.yml");
+            exec(__DIR__ . "/../bin/phinder init");
+            $this->assertFileExists("phinder.yml");
+
+            $expected = file_get_contents(__DIR__ . "/../sample/phinder.yml");
+            $got = file_get_contents("phinder.yml");
+            $this->assertNotSame($expected, $got);
+        } finally {
+            if (file_exists("phinder.yml")) {
+                unlink("phinder.yml");
+            }
+            chdir($work_dir);
+        }
+    }
+}


### PR DESCRIPTION
It is important to tell a user how to write rules. This PR introduces `phinder init` command to resolve the problem.

At first,  a user can run `phinder init` command to create a boilerplate. The file contains basic examples and describes each key of YAML. The following is example:

```yaml
# Feel free to add your own project rules to this YAML file.
# The following example describes the rule syntax.
# See the documentation for more details: https://github.com/sider/phinder/tree/master/doc
- # The rule identifier. It must be unique in the YAML file.
  id: sample.var_dump
  # Pattern syntax. The `...` pattern matches variable length arguments or array pairs.
  # As a result, this pattern matches `var_dump` function call with any arguments.
  pattern: var_dump(...)
  # The message to display when code pieces are matched with the pattern.
  message: Do not use var_dump.
  # Exceptions that can ignore this violation.
  justification: Allowed when debugging
- id: sample.in_array_without_3rd_param
  # `_` pattern mattches any single expression.
  # This means the pattern always matches `in_array` function call with any two arguments.
  pattern: in_array(_, _)
  message: Specify 3rd parameter explicitly when calling in_array to avoid unexpected comparison results.
  # You can test whether your pattern works as expected with `phinder test`.
  test:
    # Code pieces that will match your pattern.
    # This means the following codes are bad as you expected.
    fail:
      - in_array(1, $arr)
      - in_array(2, $arr)
    # Code pieces that will NOT match your pattern.
    # This means the following codes are good as you expected.
    pass:
      - in_array(3, $arr, true)
      - in_array(4, $arr, false)
```