### PR TITLE
Relax requirements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,18 +1,79 @@
 version: 2
+
+steps: &steps
+  - checkout
+  - run: sudo composer self-update
+  - run: if [ "$dependencies" = "lowest" ]; then composer update --prefer-lowest --no-interaction; fi
+  - run: if [ "$dependencies" = "highest" ]; then composer update --no-interaction; fi
+  - run: vendor/bin/phpunit
+
 jobs:
-  build:
+  php7.0-lowest-dependencies:
     docker:
-      - image: circleci/php
+      - image: circleci/php:7.0
+    environment:
+      dependencies: lowest
     steps:
-      - checkout
-      - run: sudo composer self-update
-      - restore_cache:
-          keys:
-            - composer-v1-{{ checksum "composer.lock" }}
-            - composer-v1-
-      - run: composer install
-      - save_cache:
-          key: composer-v1-{{ checksum "composer.lock" }}
-          paths:
-            - vendor
-      - run: ./vendor/bin/phpunit
+      *steps
+  php7.0-highest-dependencies:
+    docker:
+      - image: circleci/php:7.0
+    environment:
+      dependencies: highest
+    steps:
+      *steps
+  php7.1-lowest-dependencies:
+    docker:
+      - image: circleci/php:7.1
+    environment:
+      dependencies: lowest
+    steps:
+      *steps
+  php7.1-highest-dependencies:
+    docker:
+      - image: circleci/php:7.1
+    environment:
+      dependencies: highest
+    steps:
+      *steps
+  php7.2-lowest-dependencies:
+    docker:
+      - image: circleci/php:7.2
+    environment:
+      dependencies: lowest
+    steps:
+      *steps
+  php7.2-highest-dependencies:
+    docker:
+      - image: circleci/php:7.2
+    environment:
+      dependencies: highest
+    steps:
+      *steps
+  php7.3-lowest-dependencies:
+    docker:
+      - image: circleci/php:7.3
+    environment:
+      dependencies: lowest
+    steps:
+      *steps
+  php7.3-highest-dependencies:
+    docker:
+      - image: circleci/php:7.3
+    environment:
+      dependencies: highest
+    steps:
+      *steps
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - php7.0-lowest-dependencies
+      - php7.0-highest-dependencies
+      - php7.1-lowest-dependencies
+      - php7.1-highest-dependencies
+      - php7.2-lowest-dependencies
+      - php7.2-highest-dependencies
+      - php7.3-lowest-dependencies
+      - php7.3-highest-dependencies

--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,13 @@
     "bin/phinder"
   ],
   "require": {
+    "php": ">=7.0",
     "nikic/php-parser": "4.1.0",
     "funct/funct": "^1.4",
-    "symfony/yaml": "^4.1"
+    "symfony/yaml": ">=3.2"
   },
   "require-dev": {
-    "phpunit/phpunit": "^7",
+    "phpunit/phpunit": "^6.0|^7.0",
     "squizlabs/php_codesniffer": "3.*"
   }
 }


### PR DESCRIPTION
Fixes #48 

`symfony/yaml` 4.1.x on which Phinder depends requires PHP 7.1.x.
https://github.com/symfony/yaml/blob/4.1/composer.json#L19

However, in my understanding, Phinder should not need to require 4.x constraints. Fortunately, I'm experiencing [a similar situation](https://github.com/wata727/pahout/pull/18), which will work out in many cases.

In order to verify that it is working correctly, this pull request adds test matrix.