### PR TITLE
Relaxed constraint on nikic/php-parser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   ],
   "require": {
     "php": ">=7.0",
-    "nikic/php-parser": "4.1.0",
+    "nikic/php-parser": "^4.1",
     "funct/funct": "^1.4",
     "symfony/yaml": ">=3.2"
   },


### PR DESCRIPTION
Is it possible to relax the constraint on ``nikic/php-parser``?  I can't install this alongside another static analysis tool which needs php-parser 4.1.7 ....

Thanks,
Algy