### PR TITLE
Fix exit code and output destination of `phinder test`

### DIFF
--- a/src/Cli/Command/TestCommand.php
+++ b/src/Cli/Command/TestCommand.php
@@ -8,6 +8,10 @@ use Phinder\Cli\Command;
 
 class TestCommand extends Command
 {
+    const ECODE_SUCCESS = 0;
+
+    const ECODE_FAILURE = 2;
+
     protected function configure()
     {
         $this
@@ -33,7 +37,7 @@ class TestCommand extends Command
                 if (count($r->pattern->visit($phpAst)) === 0) {
                     $msg = "`$p` does not match the rule {$r->id}";
                     $msg .= ' but should match that rule.';
-                    $this->getOutput()->writeln($msg);
+                    $this->getErrorOutput()->writeln($msg);
                     ++$errorCount;
                 }
             }
@@ -43,18 +47,16 @@ class TestCommand extends Command
                 if (count($r->pattern->visit($phpAst)) !== 0) {
                     $msg = "`$p` matches the rule {$r->id}";
                     $msg .= ' but should not match that rule.';
-                    $this->getOutput()->writeln($msg);
+                    $this->getErrorOutput()->writeln($msg);
                     ++$errorCount;
                 }
             }
         }
 
         if ($errorCount === 0) {
-            $this->getErrorOutput()->writeln('No error');
-
-            return 0;
+            return self::ECODE_SUCCESS;
         } else {
-            return 1;
+            return self::ECODE_FAILURE;
         }
     }
 }

--- a/test/TestTest.php
+++ b/test/TestTest.php
@@ -13,6 +13,6 @@ class TestTest extends CliTest
     public function testFail()
     {
         $this->exec(['--config' => 'test/res/test-fail.yml']);
-        $this->assertSame($this->getStatusCode(), 1);
+        $this->assertSame($this->getStatusCode(), 2);
     }
 }


### PR DESCRIPTION
Close #65

## Exit code

The following is the list of exit codes returned by `phinder test`:

- 0: Success (No configuration error & no test failure)
- 1: Configuration error
- 2: Test failure

## Output destination

All the messages from `phinder test` are printed to stderr now!
