### PR TITLE
Look ahead when tokenizing `array`

### DIFF
--- a/grammar/Parser.y
+++ b/grammar/Parser.y
@@ -1,6 +1,6 @@
 %token T_COMMA ','
 %token T_ARROW '->'
-%token T_ARRAY 'array'
+%token T_ARRAY 'array(?![a-zA-Z0-9_])'
 %token T_DOUBLE_ARROW '=>'
 %token T_ELLIPSIS '\.\.\.'
 %token T_DOT '\.'

--- a/grammar/Parser.y
+++ b/grammar/Parser.y
@@ -1,6 +1,6 @@
 %token T_COMMA ','
 %token T_ARROW '->'
-%token T_ARRAY 'array(?![a-zA-Z0-9_])'
+%token T_ARRAY 'array(?![a-zA-Z0-9_\x80-\xff])'
 %token T_DOUBLE_ARROW '=>'
 %token T_ELLIPSIS '\.\.\.'
 %token T_DOT '\.'
@@ -20,7 +20,7 @@
 %token T_FLOAT_LITERAL '[0-9]+\.[0-9]+'
 %token T_INTEGER_LITERAL '0|[1-9][0-9]*'
 %token T_STRING_LITERAL '\'.*?\'|".*?"'
-%token T_IDENTIFIER '\?|[a-zA-Z_][a-zA-Z0-9_]*'
+%token T_IDENTIFIER '\?|[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*'
 
 %%
 

--- a/src/Pattern/Lexer.php
+++ b/src/Pattern/Lexer.php
@@ -4,7 +4,7 @@ namespace Phinder\Pattern;
 
 class Lexer
 {
-    private static $_regex = "/^(\t+|\s+|(?<T_COMMA>,)|(?<T_ARROW>->)|(?<T_ARRAY>array(?![a-zA-Z0-9_]))|(?<T_DOUBLE_ARROW>=>)|(?<T_ELLIPSIS>\.\.\.)|(?<T_DOT>\.)|(?<T_TRIPLE_VERTICAL_BAR>\|\|\|)|(?<T_TRIPLE_AMPERSAND>&&&)|(?<T_EXCLAMATION>!)|(?<T_LEFT_PAREN>\()|(?<T_RIGHT_PAREN>\))|(?<T_LEFT_BRACKET>\[)|(?<T_RIGHT_BRACKET>\])|(?<T_NULL>null)|(?<T_BOOLEAN>:bool:)|(?<T_INTEGER>:int:)|(?<T_FLOAT>:float:)|(?<T_STRING>:string:)|(?<T_BOOLEAN_LITERAL>true|false)|(?<T_FLOAT_LITERAL>[0-9]+\.[0-9]+)|(?<T_INTEGER_LITERAL>0|[1-9][0-9]*)|(?<T_STRING_LITERAL>'.*?'|\".*?\")|(?<T_IDENTIFIER>\?|[a-zA-Z_][a-zA-Z0-9_]*))/";
+    private static $_regex = "/^(\t+|\s+|(?<T_COMMA>,)|(?<T_ARROW>->)|(?<T_ARRAY>array(?![a-zA-Z0-9_\x80-\xff]))|(?<T_DOUBLE_ARROW>=>)|(?<T_ELLIPSIS>\.\.\.)|(?<T_DOT>\.)|(?<T_TRIPLE_VERTICAL_BAR>\|\|\|)|(?<T_TRIPLE_AMPERSAND>&&&)|(?<T_EXCLAMATION>!)|(?<T_LEFT_PAREN>\()|(?<T_RIGHT_PAREN>\))|(?<T_LEFT_BRACKET>\[)|(?<T_RIGHT_BRACKET>\])|(?<T_NULL>null)|(?<T_BOOLEAN>:bool:)|(?<T_INTEGER>:int:)|(?<T_FLOAT>:float:)|(?<T_STRING>:string:)|(?<T_BOOLEAN_LITERAL>true|false)|(?<T_FLOAT_LITERAL>[0-9]+\.[0-9]+)|(?<T_INTEGER_LITERAL>0|[1-9][0-9]*)|(?<T_STRING_LITERAL>'.*?'|\".*?\")|(?<T_IDENTIFIER>\?|[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*))/";
 
     private $_string;
 

--- a/src/Pattern/Lexer.php
+++ b/src/Pattern/Lexer.php
@@ -4,7 +4,7 @@ namespace Phinder\Pattern;
 
 class Lexer
 {
-    private static $_regex = "/^(\t+|\s+|(?<T_COMMA>,)|(?<T_ARROW>->)|(?<T_ARRAY>array)|(?<T_DOUBLE_ARROW>=>)|(?<T_ELLIPSIS>\.\.\.)|(?<T_DOT>\.)|(?<T_TRIPLE_VERTICAL_BAR>\|\|\|)|(?<T_TRIPLE_AMPERSAND>&&&)|(?<T_EXCLAMATION>!)|(?<T_LEFT_PAREN>\()|(?<T_RIGHT_PAREN>\))|(?<T_LEFT_BRACKET>\[)|(?<T_RIGHT_BRACKET>\])|(?<T_NULL>null)|(?<T_BOOLEAN>:bool:)|(?<T_INTEGER>:int:)|(?<T_FLOAT>:float:)|(?<T_STRING>:string:)|(?<T_BOOLEAN_LITERAL>true|false)|(?<T_FLOAT_LITERAL>[0-9]+\.[0-9]+)|(?<T_INTEGER_LITERAL>0|[1-9][0-9]*)|(?<T_STRING_LITERAL>'.*?'|\".*?\")|(?<T_IDENTIFIER>\?|[a-zA-Z_][a-zA-Z0-9_]*))/";
+    private static $_regex = "/^(\t+|\s+|(?<T_COMMA>,)|(?<T_ARROW>->)|(?<T_ARRAY>array(?![a-zA-Z0-9_]))|(?<T_DOUBLE_ARROW>=>)|(?<T_ELLIPSIS>\.\.\.)|(?<T_DOT>\.)|(?<T_TRIPLE_VERTICAL_BAR>\|\|\|)|(?<T_TRIPLE_AMPERSAND>&&&)|(?<T_EXCLAMATION>!)|(?<T_LEFT_PAREN>\()|(?<T_RIGHT_PAREN>\))|(?<T_LEFT_BRACKET>\[)|(?<T_RIGHT_BRACKET>\])|(?<T_NULL>null)|(?<T_BOOLEAN>:bool:)|(?<T_INTEGER>:int:)|(?<T_FLOAT>:float:)|(?<T_STRING>:string:)|(?<T_BOOLEAN_LITERAL>true|false)|(?<T_FLOAT_LITERAL>[0-9]+\.[0-9]+)|(?<T_INTEGER_LITERAL>0|[1-9][0-9]*)|(?<T_STRING_LITERAL>'.*?'|\".*?\")|(?<T_IDENTIFIER>\?|[a-zA-Z_][a-zA-Z0-9_]*))/";
 
     private $_string;
 

--- a/test/PatternParseTest.php
+++ b/test/PatternParseTest.php
@@ -50,6 +50,18 @@ class PatternParseTest extends TestCase
             [Node::ELLIPSIS],
         ],
 
+        'array_merge(...)' => [
+            'FunctionCall',
+            ['Identifier', 'array_merge'],
+            [Node::ELLIPSIS],
+        ],
+
+        'in_array(...)' => [
+            'FunctionCall',
+            ['Identifier', 'in_array'],
+            [Node::ELLIPSIS],
+        ],
+
         '_->a()' => [
             'MethodCall',
             ['Identifier', '_'],
@@ -110,11 +122,6 @@ class PatternParseTest extends TestCase
         ':string:' => [
             'StringLiteral',
             null,
-        ],
-
-        'array()' => [
-            'ArrayCall',
-            [],
         ],
 
         '[]' => [

--- a/test/PatternParseTest.php
+++ b/test/PatternParseTest.php
@@ -124,6 +124,11 @@ class PatternParseTest extends TestCase
             null,
         ],
 
+        'array()' => [
+            'ArrayCall',
+            [],
+        ],
+
         '[]' => [
             'ArrayCall',
             [],


### PR DESCRIPTION
This PR fixes the problem that occurs in the patterns like `array_something(...)`. Before this fix, `array_something` is tokenized into `array` and `_something` and causes an `InvalidPattern` exception. The problem is fixed by adding the look-ahead condition `(?![a-zA-Z0-9_])` to `T_ARRAY` in `grammar/Parser.y`.